### PR TITLE
Add an optional max selection limit prop

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -25,6 +25,7 @@ const App = () => {
         // searchable={false}
         clearable
         // renderOption={option => option.label}
+        maxSelect={3}
       />
 
       <Grid container spacing={2} style={{ marginTop: 20, marginBottom: 50 }}>

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -25,7 +25,7 @@ const App = () => {
         // searchable={false}
         clearable
         // renderOption={option => option.label}
-        maxSelect={3}
+        max={3}
       />
 
       <Grid container spacing={2} style={{ marginTop: 20, marginBottom: 50 }}>

--- a/src/AddItem.tsx
+++ b/src/AddItem.tsx
@@ -45,6 +45,7 @@ export default function AddItem({
   onChange,
   AddButtonProps,
   AddDialogProps,
+  disabled = false,
 }: AddItemProps) {
   const classes = useStyles();
 
@@ -80,6 +81,7 @@ export default function AddItem({
         color="default"
         classes={classes}
         onClick={() => setOpen(true)}
+        disabled={disabled}
         {...AddButtonProps}
       >
         {'\u200b'}

--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -65,7 +65,7 @@ export default function MultiSelect<T = string>({
   value: valueProp,
   onChange,
   label = '',
-  maxSelect,
+  max,
 
   disabled = false,
   multiple = true,
@@ -254,7 +254,7 @@ export default function MultiSelect<T = string>({
           <PopupContents
             multiple={true}
             value={value as Option<T>[]}
-            maxSelect={maxSelect}
+            max={max}
             {...PopupContentsProps}
           />
         ) : (

--- a/src/MultiSelect.tsx
+++ b/src/MultiSelect.tsx
@@ -65,6 +65,7 @@ export default function MultiSelect<T = string>({
   value: valueProp,
   onChange,
   label = '',
+  maxSelect,
 
   disabled = false,
   multiple = true,
@@ -253,6 +254,7 @@ export default function MultiSelect<T = string>({
           <PopupContents
             multiple={true}
             value={value as Option<T>[]}
+            maxSelect={maxSelect}
             {...PopupContentsProps}
           />
         ) : (

--- a/src/PopupContents.tsx
+++ b/src/PopupContents.tsx
@@ -6,7 +6,6 @@ import {
   createStyles,
   TextField,
   InputAdornment,
-  Typography,
 } from '@material-ui/core';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { AutocompleteChangeReason } from '@material-ui/lab/useAutocomplete';
@@ -118,9 +117,6 @@ const useStyles = makeStyles(theme =>
       },
     },
     optionIcon: { margin: theme.spacing(0, 2, 0, -(3 / 8)) },
-    maxSelectCaption: {
-      margin: theme.spacing(2, 2, 0, 2),
-    },
   })
 );
 
@@ -136,7 +132,7 @@ export default function PopupContents<T>({
 
   labelPlural = '',
   label = '',
-  maxSelect,
+  max,
 
   searchable = true,
   selectAll = true,
@@ -160,7 +156,7 @@ export default function PopupContents<T>({
       : new Set([(value as Option<T>).value])
   );
   const [disableNewSelect, setDisableNewSelect] = useState(
-    maxSelect ? selectedValues.size >= maxSelect : false
+    max ? selectedValues.size >= max : false
   );
 
   let searchBoxLabel = '';
@@ -181,24 +177,15 @@ export default function PopupContents<T>({
     setSelectedValues(
       new Set(newValue.map((item: { value: T }) => item.value))
     );
-    if (maxSelect && newValue.length >= maxSelect) {
+    if (max && newValue.length >= max) {
       setDisableNewSelect(true);
-    } else if (maxSelect && disableNewSelect) {
+    } else if (max && disableNewSelect) {
       setDisableNewSelect(false);
     }
   };
 
   return (
     <>
-      {maxSelect && (
-        <Typography
-          variant="caption"
-          display="block"
-          className={classes.maxSelectCaption}
-        >
-          {selectedValues.size} of max {maxSelect} selected
-        </Typography>
-      )}
       <Autocomplete
         noOptionsText={`No ${labelPlural || label || 'options'}`}
         renderOption={(option, { selected }) => {
@@ -345,6 +332,7 @@ export default function PopupContents<T>({
         countText={countText}
         value={value}
         options={options}
+        max={max}
       />
     </>
   );

--- a/src/PopupContents.tsx
+++ b/src/PopupContents.tsx
@@ -155,9 +155,7 @@ export default function PopupContents<T>({
       ? new Set()
       : new Set([(value as Option<T>).value])
   );
-  const [disableNewSelect, setDisableNewSelect] = useState(
-    max ? selectedValues.size >= max : false
-  );
+  const disableNewSelect = max ? selectedValues.size >= max : false;
 
   let searchBoxLabel = '';
   if (searchable) {
@@ -177,11 +175,6 @@ export default function PopupContents<T>({
     setSelectedValues(
       new Set(newValue.map((item: { value: T }) => item.value))
     );
-    if (max && newValue.length >= max) {
-      setDisableNewSelect(true);
-    } else if (max && disableNewSelect) {
-      setDisableNewSelect(false);
-    }
   };
 
   return (

--- a/src/PopupFooter.tsx
+++ b/src/PopupFooter.tsx
@@ -44,6 +44,7 @@ export default function PopupFooter({
   countText,
   value,
   options,
+  max,
 }: PopupFooterProps) {
   const classes = useStyles();
 
@@ -69,7 +70,10 @@ export default function PopupFooter({
       >
         <Grid item>
           <Typography variant="button" className={classes.count}>
-            {countText ?? `${value.length} of ${options.length}`}
+            {countText ??
+              `${value.length} of ${options.length}${
+                max ? ', max ' + max : ''
+              }`}
           </Typography>
         </Grid>
         {selectAll ? (

--- a/src/props/AddItem.ts
+++ b/src/props/AddItem.ts
@@ -5,6 +5,7 @@ export type AddItemProps = {
   multiple: boolean;
   value: PopupContentsProps<string>['value'];
   onChange: PopupContentsProps<string>['onChange'];
+  disabled?: boolean;
   AddButtonProps?: Partial<ButtonProps>;
   AddDialogProps?: {
     title?: React.ReactNode;

--- a/src/props/MultiSelect.ts
+++ b/src/props/MultiSelect.ts
@@ -24,7 +24,7 @@ interface MultiSelectCommonProps<T>
   /** Show the backdrop when the dropdown popup is open */
   backdrop?: boolean;
   /** Maximum number of items can be selected */
-  maxSelect?: number;
+  max?: number;
   /** Callback fired when popup opens */
   onOpen?: () => void;
   /** Callback fired when popup closes */

--- a/src/props/MultiSelect.ts
+++ b/src/props/MultiSelect.ts
@@ -23,6 +23,8 @@ interface MultiSelectCommonProps<T>
   displayEmpty?: boolean;
   /** Show the backdrop when the dropdown popup is open */
   backdrop?: boolean;
+  /** Maximum number of items can be selected */
+  maxSelect?: number;
   /** Callback fired when popup opens */
   onOpen?: () => void;
   /** Callback fired when popup closes */

--- a/src/props/PopupContents.ts
+++ b/src/props/PopupContents.ts
@@ -101,7 +101,7 @@ export type PopupContentsMultipleProps<T> = {
   multiple: true;
   options: Option<T>[];
   value: Option<T>[];
-  maxSelect?: number;
+  max?: number;
   onChange: NonNullable<UseAutocompleteMultipleProps<Option<T>>['onChange']>;
 } & PopupContentsCommonProps<T>;
 
@@ -109,7 +109,7 @@ export type PopupContentsSingleProps<T> = {
   multiple: false;
   options: Option<T>[];
   value: Option<T> | null;
-  maxSelect?: null;
+  max?: undefined;
   onChange: NonNullable<UseAutocompleteSingleProps<Option<T>>['onChange']>;
 } & PopupContentsCommonProps<T>;
 

--- a/src/props/PopupContents.ts
+++ b/src/props/PopupContents.ts
@@ -1,4 +1,4 @@
-import { TextFieldProps, StandardProps, ButtonProps } from '@material-ui/core';
+import { TextFieldProps, StandardProps } from '@material-ui/core';
 import {
   AutocompleteProps,
   AutocompleteClassKey,
@@ -101,6 +101,7 @@ export type PopupContentsMultipleProps<T> = {
   multiple: true;
   options: Option<T>[];
   value: Option<T>[];
+  maxSelect?: number;
   onChange: NonNullable<UseAutocompleteMultipleProps<Option<T>>['onChange']>;
 } & PopupContentsCommonProps<T>;
 
@@ -108,6 +109,7 @@ export type PopupContentsSingleProps<T> = {
   multiple: false;
   options: Option<T>[];
   value: Option<T> | null;
+  maxSelect?: null;
   onChange: NonNullable<UseAutocompleteSingleProps<Option<T>>['onChange']>;
 } & PopupContentsCommonProps<T>;
 

--- a/src/props/PopupFooter.ts
+++ b/src/props/PopupFooter.ts
@@ -8,4 +8,5 @@ export type PopupFooterProps = {
   countText?: React.ReactNode;
   value: any;
   options: any[];
+  max?: number;
 };

--- a/stories/MultiSelect.stories.tsx
+++ b/stories/MultiSelect.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { withKnobs, boolean, text } from '@storybook/addon-knobs';
+import { withKnobs, boolean, text, number } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import MultiSelect from '../src';
@@ -32,6 +32,7 @@ export const Multiple = () => {
       value={value}
       onChange={handleChange}
       disabled={boolean('Disabled', false)}
+      maxSelect={number('Max 3', 3)}
       searchable={boolean('Searchable', true)}
       freeText={boolean('Free text', false)}
       selectAll={boolean('Select all', true)}

--- a/stories/MultiSelect.stories.tsx
+++ b/stories/MultiSelect.stories.tsx
@@ -32,7 +32,7 @@ export const Multiple = () => {
       value={value}
       onChange={handleChange}
       disabled={boolean('Disabled', false)}
-      maxSelect={number('Max 3', 3)}
+      max={number('Max 3', 3)}
       searchable={boolean('Searchable', true)}
       freeText={boolean('Free text', false)}
       selectAll={boolean('Select all', true)}


### PR DESCRIPTION
This PR adds an optional prop `maxSelect`, which prevents user from selecting more items than the number it specifies. 

A video preview:

https://user-images.githubusercontent.com/34177142/105129997-52c7f900-5b3a-11eb-8571-7f61a7d00ad3.mov

